### PR TITLE
Fix for Issue #16: turn off tx-checksum-ip-generic on pdn interface

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,7 @@
+#################################
 # openair-cn-cups
+#################################
+
 Control User Plane Separation of SPGW-C and SPGW-U
 ├── http://www.openairinterface.org/?page_id=698 
 

--- a/src/spgwu/simpleswitch/pfcp_switch.cpp
+++ b/src/spgwu/simpleswitch/pfcp_switch.cpp
@@ -256,7 +256,7 @@ int pfcp_switch::create_pdn_socket (const char * const ifname)
 //------------------------------------------------------------------------------
 void pfcp_switch::setup_pdn_interfaces()
 {
-  std::string cmd = fmt::format("ip link set dev {0} down > /dev/null 2>&1; ip link del {0} > /dev/null 2>&1; sync; sleep 1; ip link add {0} type dummy; ip link set dev {0} up", PDN_INTERFACE_NAME);
+  std::string cmd = fmt::format("ip link set dev {0} down > /dev/null 2>&1; ip link del {0} > /dev/null 2>&1; sync; sleep 1; ip link add {0} type dummy; ethtool -K {0} tx-checksum-ip-generic off; ip link set dev {0} up", PDN_INTERFACE_NAME);
   int rc = system ((const char*)cmd.c_str());
 
   for (auto it : spgwu_cfg.pdns) {


### PR DESCRIPTION
Turn off tx-checksum-ip-generic on pdn interface by using ethtool after creation of the pdn interface.